### PR TITLE
Add support for fuzzing websockets

### DIFF
--- a/src/burp/FastResponseVariations.java
+++ b/src/burp/FastResponseVariations.java
@@ -2,11 +2,27 @@ package burp;
 
 import java.util.*;
 
-public class FastResponseVariations implements IResponseVariations {
+import burp.api.montoya.core.ByteArray;
 
+public class FastResponseVariations implements IResponseVariations {
+ 
     HashMap<String, Integer> attributes;
-    HashSet<String> invariantAttributes = new HashSet<>(Arrays.asList(new String[]{"start", "code", "headers", "newlines", "spaces"}));
+    HashSet<String> invariantAttributes;
     HashSet<String> variantAttributes;
+
+    // http
+    public FastResponseVariations() {
+        this.invariantAttributes = new HashSet<>(Arrays.asList(new String[]{"start", "code", "headers", "newlines", "spaces"}));
+        this.variantAttributes = new HashSet<>();
+    }
+
+    // ws
+    public FastResponseVariations(String type) {
+        if ("ws".equalsIgnoreCase(type)) {
+            this.invariantAttributes = new HashSet<>(Arrays.asList(new String[]{"messageCount", "messageTypes", "messageLengths", "spaces", "tags"}));
+            this.variantAttributes = new HashSet<>();
+        }
+    }
 
     @Override
     public List<String> getVariantAttributes() {
@@ -67,6 +83,79 @@ public class FastResponseVariations implements IResponseVariations {
                 return BulkUtilities.byteCount(bytes, '<', bodyStart, bytes.length);
             case "equals":
                 return BulkUtilities.byteCount(bytes, '=', bodyStart, bytes.length);
+        }
+        return -1;
+    }
+
+    public void updateWith(WebSocketMessageImpl wsMessage) {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+            for (String key: invariantAttributes) {
+                attributes.put(key, calculateAttribute(wsMessage, key));
+            }
+        } else {
+            // relegate entries from invariant to variant if they don't match
+            Iterator<String> iter = invariantAttributes.iterator();
+            while (iter.hasNext()) {
+                String key = iter.next();
+                if (calculateAttribute(wsMessage, key) != attributes.get(key)) {
+                    iter.remove();
+                    variantAttributes.add(key);
+                }
+            }
+        }
+    }
+
+    private int calculateAttribute(WebSocketMessageImpl wsMessage, String attribute) {
+        switch (attribute) {
+            case "messageCount":
+                return wsMessage.responses().size();
+            case "messageTypes":
+                if (wsMessage.responseTypes().isEmpty()) return 0;
+
+                // create a chronological sequence (e.g. TBTT)
+                StringBuilder pattern = new StringBuilder();
+                for (WebSocketMessageImpl.MessageType type : wsMessage.responseTypes()) {
+                    pattern.append(type == WebSocketMessageImpl.MessageType.TEXT ? 'T' : 'B');
+                }
+                // workaround to get the result as number
+                byte[] bytes = pattern.toString().getBytes();
+                StringBuilder hex = new StringBuilder();
+                for (byte b : bytes) {
+                    hex.append(String.format("%02X", b));
+                }
+        
+                return Integer.parseInt(hex.substring(0, Math.min(8, hex.length())), 16);
+            case "messageLengths":
+                if (wsMessage.responses().isEmpty()) return 0;
+        
+                // same workaround
+                StringBuilder hexBuilder = new StringBuilder();
+                for (ByteArray message : wsMessage.responses()) {
+                    hexBuilder.append(String.format("%04X", message.length()));
+                }
+        
+                return Integer.parseInt(hexBuilder.substring(0, Math.min(8, hexBuilder.length())), 16);
+            case "spaces":
+                if (wsMessage.responses().isEmpty()) return 0;
+
+                // same workaround
+                StringBuilder spaces = new StringBuilder();
+                for (ByteArray message : wsMessage.responses()) {
+                    spaces.append(String.format("%04X", BulkUtilities.byteCount(message.getBytes(), ' ', 0, message.length())));
+                }
+
+                return Integer.parseInt(spaces.substring(0, Math.min(8, spaces.length())), 16);
+            case "tags":
+                if (wsMessage.responses().isEmpty()) return 0;
+
+                // same workaround
+                StringBuilder tags = new StringBuilder();
+                for (ByteArray message : wsMessage.responses()) {
+                    tags.append(String.format("%04X", BulkUtilities.byteCount(message.getBytes(), '<', 0, message.length())));
+
+                return Integer.parseInt(tags.substring(0, Math.min(8, tags.length())), 16);
+                }
         }
         return -1;
     }

--- a/src/burp/QuantitativeMeasurements.java
+++ b/src/burp/QuantitativeMeasurements.java
@@ -21,6 +21,12 @@ public class QuantitativeMeasurements {
         Collections.sort(measurements);
     }
 
+    // in this case it's easier to have 2 methods instead of using Object
+    void updateWith(WebSocketMessageImpl resp) {
+        measurements.add(resp.getAttribute(key));
+        Collections.sort(measurements);
+    }
+
     void merge(QuantitativeMeasurements newMeasurements) {
         measurements.addAll(newMeasurements.measurements);
         Collections.sort(measurements);

--- a/src/burp/WebSocketMessageImpl.java
+++ b/src/burp/WebSocketMessageImpl.java
@@ -1,0 +1,196 @@
+package burp;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.ui.contextmenu.WebSocketMessage;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.core.Annotations;
+import burp.api.montoya.websocket.Direction;
+import burp.api.montoya.websocket.BinaryMessage;
+import burp.api.montoya.websocket.TextMessage;
+import burp.api.montoya.websocket.extension.ExtensionWebSocketCreation;
+import burp.api.montoya.websocket.extension.ExtensionWebSocketCreationStatus;
+import burp.api.montoya.websocket.extension.ExtensionWebSocketMessageHandler;
+
+import static burp.Scan.throttle;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+public class WebSocketMessageImpl implements WebSocketMessage {
+    private final ByteArray payload;
+    private final Direction direction;
+    private final HttpRequest upgradeRequest;
+    private final Annotations annotations;
+
+    private final List<ByteArray> responses;
+    private final List<Long> responseTimes;
+    private final List<MessageType> responseTypes;
+    private final long timeout; // window of time to wait for replies
+
+    public enum MessageType {
+        TEXT, BINARY
+    }
+
+    private IResponseVariations attributes;
+
+    @Override
+    public ByteArray payload() {
+        return payload;
+    }
+
+    @Override 
+    public Direction direction() {
+        return direction;
+    }
+
+    @Override 
+    public HttpRequest upgradeRequest() {
+        return upgradeRequest;
+    }
+
+    @Override
+    public Annotations annotations() {
+        return annotations;
+    }
+
+    public List<ByteArray> responses() {
+        return responses;
+    }
+
+    public List<Long> responseTimes() {
+        return responseTimes;
+    }
+
+    public long responseTime() {
+        if (responseTimes.isEmpty()) {
+            return Long.MAX_VALUE;
+        }
+        return Collections.min(responseTimes);
+    }
+
+    public List<MessageType> responseTypes() {
+        return responseTypes;
+    }
+
+    IResponseVariations getAttributes() {
+        if (attributes == null) {
+            // analyzeResponseVariations accepts multiple responses at the same time
+            byte[][] byteResponses = responses.stream()
+                                     .map(ByteArray::getBytes)
+                                     .toArray(byte[][]::new);
+            attributes = Utilities.helpers.analyzeResponseVariations(byteResponses);
+        }
+        return attributes;
+    }
+
+    long getAttribute(String attribute) {
+        switch(attribute) {
+            case "time":
+                return responseTimes.isEmpty() ? Long.MAX_VALUE : Collections.min(responseTimes);
+            case "failed":
+                return responses.isEmpty() ? 1 : 0;
+            case "timedout":
+                return responses.isEmpty() ? 1 : 0;
+        }
+
+        try {
+            return getAttributes().getAttributeValue(attribute, 0);
+        } catch (IllegalArgumentException e) {
+            Utilities.out("Invalid attribute: "+attribute);
+            Utilities.out("Supported attributes: "+getAttributes().getInvariantAttributes() + getAttributes().getVariantAttributes());
+            throw new RuntimeException("Invalid attribute: "+attribute);
+        }
+
+    }
+
+    public WebSocketMessageImpl(ByteArray payload, Direction direction, HttpRequest upgradeRequest, Annotations annotations, long timeout) {
+        this.payload = payload;
+        this.direction = direction;
+        this.upgradeRequest = upgradeRequest;
+        this.annotations = annotations;
+        this.timeout = timeout;
+
+        this.responses = new ArrayList<>();
+        this.responseTimes = new ArrayList<>();
+        this.responseTypes = new ArrayList<>();
+
+        wsRequest(upgradeRequest, payload);
+    }
+
+    private void wsRequest(HttpRequest upgradeRequest, ByteArray payload_tmp) {
+        final MontoyaApi api = Utilities.montoyaApi;
+
+        ByteArray payload;
+        // remove FUZZ placeholder in case it's still here, can happen sometimes
+        Pattern pattern = Pattern.compile("FU(.*?)ZZ");
+        Matcher matcher = pattern.matcher(payload_tmp.toString());
+        if (matcher.find()) {
+            String payload_s = matcher.replaceAll("$1");
+            payload = ByteArray.byteArray(payload_s);
+        } else {
+            payload = payload_tmp;
+        }
+
+        throttle();
+
+        try {
+            ExtensionWebSocketCreation webSocketCreation = api.websockets().createWebSocket(upgradeRequest);
+        
+            if (webSocketCreation.status() != ExtensionWebSocketCreationStatus.SUCCESS) {
+                Utilities.out("WebSocket creation failed: " + webSocketCreation.status());
+                Utilities.out(upgradeRequest.toString());
+                return;
+            }
+
+            webSocketCreation.webSocket().ifPresent(extensionWebSocket -> {
+                long startTime = System.nanoTime();
+
+                extensionWebSocket.registerMessageHandler(new ExtensionWebSocketMessageHandler() {
+                    @Override
+                    public void textMessageReceived(TextMessage message) {
+                        synchronized (responses) {
+                            responseTimes.add(System.nanoTime() - startTime);
+                            responses.add(ByteArray.byteArray(message.payload()));
+                            responseTypes.add(MessageType.TEXT);
+                        }
+                    }
+
+                    @Override
+                    public void binaryMessageReceived(BinaryMessage message) {
+                        synchronized (responses) {
+                            responseTimes.add(System.nanoTime() - startTime);
+                            responses.add(message.payload());
+                            responseTypes.add(MessageType.BINARY);
+                        }
+                    }
+                });
+
+                // messages to be sent before the payloads (e.g. auth)
+                String preMessage = Utilities.globalSettings.getString("ws: pre-message");
+
+                if (!preMessage.isEmpty()) {
+                    String[] preMessages = preMessage.split("FUZZ");
+                    for (String value : preMessages) {
+                        extensionWebSocket.sendTextMessage(value);
+                    }
+                }
+
+                extensionWebSocket.sendBinaryMessage(payload);
+
+                try {
+                    Thread.sleep(timeout * 1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    extensionWebSocket.close();
+                }
+            });
+
+        } catch (Exception e) {
+            Utilities.out("WebSocket request failed: " + e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

This PR lays the foundation for fuzzing WebSockets.  
Details can be found in the Backslash Powered Scanner [PR](https://github.com/PortSwigger/backslash-powered-scanner/pull/30).

Most changes involve replacing hardcoded HTTP objects with generic objects, adding conditions to check the object type, and adjusting behavior accordingly. The main logic and flow have been preserved as much as possible.

The `WebSocketMessageImpl` class is designed to be similar to the `Resp` class.
Any question don't hesitate to contact me.