### PR TITLE
Automation and fix for JSON in WebSockets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     // implementation files('turbo-intruder-all.jar') // contains albinowaxUtils
     implementation files('albinowaxUtils-all.jar') // contains albinowaxUtils
+    implementation 'org.json:json:20231013'
 }
 
 sourceSets {

--- a/src/burp/WebSocketMessageImpl.java
+++ b/src/burp/WebSocketMessageImpl.java
@@ -27,7 +27,7 @@ public class WebSocketMessageImpl implements WebSocketMessage {
     private final List<ByteArray> responses;
     private final List<Long> responseTimes;
     private final List<MessageType> responseTypes;
-    private final long timeout; // window of time to
+    private final long timeout; // window of time to listen for incoming messages
 
     public enum MessageType {
         TEXT, BINARY
@@ -122,7 +122,7 @@ public class WebSocketMessageImpl implements WebSocketMessage {
         final MontoyaApi api = Utilities.montoyaApi;
 
         ByteArray payload;
-        // remove FUZZ placeholder in case it's still here, can happen sometimes
+        // remove FUZZ placeholder in case it's still here, happens on initialization
         Pattern pattern = Pattern.compile("FU(.*?)ZZ");
         Matcher matcher = pattern.matcher(payload_tmp.toString());
         if (matcher.find()) {
@@ -139,7 +139,6 @@ public class WebSocketMessageImpl implements WebSocketMessage {
         
             if (webSocketCreation.status() != ExtensionWebSocketCreationStatus.SUCCESS) {
                 Utilities.out("WebSocket creation failed: " + webSocketCreation.status());
-                Utilities.out(upgradeRequest.toString());
                 return;
             }
 
@@ -184,7 +183,7 @@ public class WebSocketMessageImpl implements WebSocketMessage {
                         extensionWebSocket.sendTextMessage(value);
                     }
                 }
-
+                
                 extensionWebSocket.sendTextMessage(payload.toString());
 
                 try {


### PR DESCRIPTION
This PR introduces some automation and a small fix for WebSockets.

- If the message is in JSON or Socket.IO format, the extension will automatically fuzz all fields and JSON escape the payloads.
- If it's not, you can wrap the desired insertion point with FUZZ, and the extension will target that area.
- If no marker is provided, the extension will fuzz the entire message as a single unit.
