### PR TITLE
fix bug when >1 ws responses, improved settings

### DIFF
--- a/src/burp/WebSocketMessageImpl.java
+++ b/src/burp/WebSocketMessageImpl.java
@@ -152,6 +152,7 @@ public class WebSocketMessageImpl implements WebSocketMessage {
                             responseTimes.add(System.nanoTime() - startTime);
                             responses.add(ByteArray.byteArray(message.payload()));
                             responseTypes.add(MessageType.TEXT);
+                            Utilities.out(message.payload());
                         }
                     }
 
@@ -161,6 +162,7 @@ public class WebSocketMessageImpl implements WebSocketMessage {
                             responseTimes.add(System.nanoTime() - startTime);
                             responses.add(message.payload());
                             responseTypes.add(MessageType.BINARY);
+                            Utilities.out(message.payload().toString());
                         }
                     }
                 });
@@ -181,13 +183,15 @@ public class WebSocketMessageImpl implements WebSocketMessage {
                     String[] preMessages = preMessage.split("FUZZ");
                     for (String value : preMessages) {
                         extensionWebSocket.sendTextMessage(value);
+                        Utilities.out(value.toString());
                     }
                 }
                 
                 extensionWebSocket.sendTextMessage(payload.toString());
+                Utilities.out(payload.toString());
 
                 try {
-                    Thread.sleep(timeout * 1000);
+                    Thread.sleep(timeout);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 } finally {

--- a/src/burp/WsAttack.java
+++ b/src/burp/WsAttack.java
@@ -3,6 +3,8 @@ package burp;
 import java.util.*;
 
 import burp.api.montoya.core.ByteArray;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 class WsAttack {
     final static int UNINITIALISED = -1;
@@ -126,9 +128,15 @@ class WsAttack {
     private WsAttack add(WebSocketMessageImpl webSocketMessage, String anchor) {
         assert (firstRequest != null);
 
-        for (ByteArray responseByteArray : webSocketMessage.responses()) {
-            byte[] response = responseByteArray.getBytes();
-            responseKeywords.updateWith(response);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            for (ByteArray responseByteArray : webSocketMessage.responses()) {
+                baos.write(responseByteArray.getBytes());
+            }
+
+            responseKeywords.updateWith(baos.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to concatenate responses", e);
         }
         responseDetails.updateWith(webSocketMessage);
 


### PR DESCRIPTION
- Fixed a bug that was affecting analysis when handling multiple WebSocket messages.
- Added debug print statements to help testers verify configuration settings and ensure messages are being sent correctly.
- Changed timeout setting from seconds to milliseconds to allow for more granular control.